### PR TITLE
Add function for bias & refactor common trunk encoder

### DIFF
--- a/transformer/src/experiment/encoder.py
+++ b/transformer/src/experiment/encoder.py
@@ -1,0 +1,30 @@
+from keras.layers import Dense, Input
+
+
+class Encoder:
+    def __init__(self):
+        pass
+
+    def encode(self):
+        pass
+
+    def input_dims(self):
+        pass
+
+
+class FcEncoder(Encoder):
+    def __init__(self):
+        pass
+
+    def encode(self, inputs_dims):
+        inputs = Input(shape=inputs_dims, name='input')
+        x = Dense(units=200, activation='elu', kernel_initializer='RandomNormal')(inputs)
+        x = Dense(units=200, activation='elu', kernel_initializer='RandomNormal')(x)
+        x = Dense(units=200, activation='elu', kernel_initializer='RandomNormal')(x)
+        return inputs, x
+
+    def reshape_input(self, x):
+        return x.reshape(x.shape[0], -1)
+
+    def input_dims(self, x):
+        return (x.shape[1],)

--- a/transformer/src/experiment/encoder.py
+++ b/transformer/src/experiment/encoder.py
@@ -1,5 +1,5 @@
-from keras.layers import Dense, Input
-
+from keras.layers import Dense, Input, Flatten
+import tensorflow as tf
 
 class Encoder:
     def __init__(self):
@@ -28,3 +28,29 @@ class FcEncoder(Encoder):
 
     def input_dims(self, x):
         return (x.shape[1],)
+
+
+class ResnetEncoder(Encoder):
+    def __init__(self):
+        pass
+
+    def encode(self, inputs_dims):
+        base_model = tf.keras.applications.ResNet50(weights='imagenet', include_top=False, input_shape=(32, 32, 3))
+        for layer in base_model.layers:
+            layer.trainable = False
+        x = Flatten()(base_model.output)
+        return base_model.input, x
+
+    # Pretrained resnet wants inputs to be of the shape (h, w, 3) with h, w >= 32
+    # x.shape => (batch_size, 28, 28)
+    def reshape_input(self, x):
+        # x.shape => (batch_size, 32, 32)
+        x = tf.pad(x, [[0, 0], [2, 2], [2, 2]])
+        # x.shape => (batch_size, 32, 32, 1)
+        x = tf.expand_dims(x, axis=3, name=None)
+        # x.shape => (batch_size, 32, 32, 3)
+        x = tf.repeat(x, 3, axis=3)
+        return x
+
+    def input_dims(self, x):
+        return (x.shape[1:])

--- a/transformer/src/experiment/ihdp_main.py
+++ b/transformer/src/experiment/ihdp_main.py
@@ -14,6 +14,7 @@ from tensorflow.keras.optimizers import RMSprop, SGD, Adam
 from keras.callbacks import EarlyStopping, ModelCheckpoint, TensorBoard, ReduceLROnPlateau, TerminateOnNaN
 from idhp_data import *
 from tensorflow.python.ops.numpy_ops import np_config
+
 np_config.enable_numpy_behavior()
 from encoder import *
 
@@ -82,7 +83,6 @@ def train_and_predict_dragons(t_train, t_test, y_train, y_test, x_train, x_test,
     y_test = y_test.astype('float32')
 
     print("I am here making dragonnet")
-
 
     dragonnet = make_dragonnet(encoder, input_dims, 0.01)
 
@@ -180,7 +180,7 @@ def run_mnist(args: argparse, output_dir: str):
     for is_targeted_regularization in [True, False]:
         print("Is targeted regularization: {}".format(is_targeted_regularization))
         test_outputs, train_output = train_and_predict_dragons(t_train, t_test, y_train, y_test, x_train, x_test,
-                                                               encoder = encoder,
+                                                               encoder=encoder,
                                                                targeted_regularization=is_targeted_regularization,
                                                                output_dir=output_dir,
                                                                knob_loss=mnist_dragonnet_loss_binarycross,
@@ -189,11 +189,14 @@ def run_mnist(args: argparse, output_dir: str):
                                                                val_split=0.2,
                                                                batch_size=args.batch_size)
 
+
 # TODO: Add plug for ResNet and Transformer
 def get_encoder(encoder_type: str):
-    if encoder_type == "fc":
+    if encoder_type == "resnet":
+        return ResnetEncoder()
+    else:
         return FcEncoder()
-    return FcEncoder()
+
 
 def turn_knob(args: argparse):
     output_dir = os.path.join(args.output_base_dir, args.knob)
@@ -208,6 +211,7 @@ def main():
     parser.add_argument('--dry-run', type=bool, default=True)
     parser.add_argument('--ratio', type=float, default=1.)
     parser.add_argument('--batch-size', type=int, default=64)
+    # Possible values of encoder are 'fc', 'resnet'
     parser.add_argument('--encoder', type=str, default='fc')
 
     args = parser.parse_args()

--- a/transformer/src/experiment/models.py
+++ b/transformer/src/experiment/models.py
@@ -7,6 +7,7 @@ from keras.models import Model
 from keras import regularizers
 import numpy as np
 
+
 def binary_classification_loss(concat_true, concat_pred):
     t_true = concat_true[:, 1]
     t_pred = concat_pred[:, 2]
@@ -27,6 +28,7 @@ def regression_loss(concat_true, concat_pred):
     loss1 = tf.reduce_sum(t_true * tf.square(y_true - y1_pred))
 
     return loss0 + loss1
+
 
 def y_binary_classification_loss(concat_true, concat_pred):
     """
@@ -59,14 +61,17 @@ def y_binary_classification_loss(concat_true, concat_pred):
         y_loss = tf.reduce_sum(K.binary_crossentropy(y_true, y_pred))
     return y_loss
 
+
 def dragonnet_loss_binarycross(concat_true, concat_pred):
     return regression_loss(concat_true, concat_pred) + binary_classification_loss(concat_true, concat_pred)
+
 
 def mnist_dragonnet_loss_binarycross(concat_true, concat_pred):
     """
     Total Classification loss - used for MNIST causal effect
     """
     return y_binary_classification_loss(concat_true, concat_pred) + binary_classification_loss(concat_true, concat_pred)
+
 
 def treatment_accuracy(concat_true, concat_pred):
     t_true = concat_true[:, 1]
@@ -127,7 +132,7 @@ def make_tarreg_loss(ratio=1., dragonnet_loss=dragonnet_loss_binarycross):
     return tarreg_ATE_unbounded_domain_loss
 
 
-def make_dragonnet(input_dim, reg_l2):
+def make_dragonnet(encoder, input_dims, reg_l2):
     """
     Neural net predictive model. The dragon has three heads.
     :param input_dim:
@@ -136,12 +141,8 @@ def make_dragonnet(input_dim, reg_l2):
     """
     t_l1 = 0.
     t_l2 = reg_l2
-    inputs = Input(shape=(input_dim,), name='input')
 
-    # representation
-    x = Dense(units=200, activation='elu', kernel_initializer='RandomNormal')(inputs)
-    x = Dense(units=200, activation='elu', kernel_initializer='RandomNormal')(x)
-    x = Dense(units=200, activation='elu', kernel_initializer='RandomNormal')(x)
+    inputs, x = encoder.encode(input_dims)
 
     t_predictions = Dense(units=1, activation='sigmoid')(x)
 


### PR DESCRIPTION
#3 
- Since we are going to add ResNet and Transformer as common trunk (encoder), refactored the dragonnet encoder out.
- Added a bias calculation function between controlled and treated groups.
- Plugged in pretrained resnet50, can be used by either changing the default `encoder` value in the main function or passing `"resnet"` and command line argument. 